### PR TITLE
Fix an issue where even fully qualified issue references got rewritten

### DIFF
--- a/gh-issues-import.py
+++ b/gh-issues-import.py
@@ -301,11 +301,11 @@ def import_comments(comments, issue_number, new_issue_numbers):
 	
 def fix_issue_links(message, new_issue_numbers):
 	for old_num, new_num in new_issue_numbers.items():
-		message = message.replace("#" + str(old_num), "#$#$" + str(new_num))
+		message = re.sub(r'(^|\s)#' + str(old_num), r'\1#$#$' + str(new_num), message)
 		
-	message = re.sub(r' #([0-9]+)', r' https://github.com/docker/pinata/issues/\1', message)
+	message = re.sub(r'(^|\s)#([0-9]+)', r'\1docker/pinata#\2', message)
 		
-	message = message.replace("#$#$", "#" )
+	message = message.replace("#$#$", "#")
 	return message
 
 # Will only import milestones and issues that are in use by the imported issues, and do not exist in the target repository


### PR DESCRIPTION
Previously strings like '#[old_id]' were rewritten to '#[new_id]' even if the '#[old_id]' string was fully qualified like org/other-repo#[old_id]. This also matches issue references with arbitrary whitespace or beginning of string prefixes rather than just space.